### PR TITLE
Improved ANSI C compatibility

### DIFF
--- a/src/cbuffer.c
+++ b/src/cbuffer.c
@@ -4,6 +4,7 @@ BufferStatus BUF_init(Buffer* b, void* arr, uint16_t length, uint8_t width){
     /* ensure that the length is a power of 2 */
     uint8_t lengthOk = 0;
     uint16_t possibleLength = 1;
+    uint16_t i;
     while(possibleLength < 16384){
         if(possibleLength == length){
             lengthOk = 1;
@@ -20,7 +21,6 @@ BufferStatus BUF_init(Buffer* b, void* arr, uint16_t length, uint8_t width){
         b->dataPtr = dataBuf;
         
         /* erase the buffer */
-        uint16_t i;
         for(i = 0; i < length; i++){
             dataBuf[i] = 0;
         }


### PR DESCRIPTION
ANSI C only allows variable declarations at the beginning of a function, so I had to move the "uint16_t i" to get this module to compile on MikroC for PIC. I believe that while newer revisions of C allow declarations like what was originally here, they still accept the legacy 'all at the beginning' style.

If i'm right about that, this is a simple change that lets this buffer package work perfectly out of the box for a wider range of compilers.
